### PR TITLE
Refactor context

### DIFF
--- a/src/main/java/io/radanalytics/SparkContextProvider.java
+++ b/src/main/java/io/radanalytics/SparkContextProvider.java
@@ -5,7 +5,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 
 public class SparkContextProvider {
    private static final SparkContextProvider instance = new SparkContextProvider();
-   
+
    private SparkConf sparkConf;
    private JavaSparkContext sparkContext;
 

--- a/src/main/java/io/radanalytics/SparkContextProvider.java
+++ b/src/main/java/io/radanalytics/SparkContextProvider.java
@@ -1,0 +1,21 @@
+package io.radanalytics;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+
+public class SparkContextProvider {
+   private static final SparkContextProvider instance = new SparkContextProvider();
+   
+   private SparkConf sparkConf;
+   private JavaSparkContext sparkContext;
+
+   private SparkContextProvider() {
+       this.sparkConf = new SparkConf().setAppName("JavaSparkPi");
+       this.sparkConf.setJars(new String[]{"/tmp/src/target/SparkPiBoot-0.0.1-SNAPSHOT.jar.original"});
+       this.sparkContext = new JavaSparkContext(sparkConf);
+   }
+
+   public static JavaSparkContext getContext() {
+       return instance.sparkContext;
+   }
+}

--- a/src/main/java/io/radanalytics/SparkPiProducer.java
+++ b/src/main/java/io/radanalytics/SparkPiProducer.java
@@ -3,7 +3,6 @@ package io.radanalytics;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.api.java.JavaRDD;
@@ -11,9 +10,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 
 public class SparkPiProducer implements Serializable {
     public String GetPi() {
-        SparkConf sparkConf = new SparkConf().setAppName("JavaSparkPi");
-        sparkConf.setJars(new String[]{"/tmp/src/target/SparkPiBoot-0.0.1-SNAPSHOT.jar.original"});
-        JavaSparkContext jsc = new JavaSparkContext(sparkConf);
+        JavaSparkContext jsc = SparkContextProvider.getContext();
 
         int slices = 2;
         int n = 100000 * slices;

--- a/src/main/java/io/radanalytics/SparkPiProducer.java
+++ b/src/main/java/io/radanalytics/SparkPiProducer.java
@@ -29,8 +29,6 @@ public class SparkPiProducer implements Serializable {
 
         String ret = "Pi is rouuuughly " + 4.0 * count / n;
 
-        jsc.stop();
-
         return ret;
     }
 }


### PR DESCRIPTION
this change will make multiple requests much more solid. the spark context is moved to a singleton object to allow jobs to queue up, this improves the user experience when reloading the page or opening multiple browsers against the same page at the same time.